### PR TITLE
Variation max size and depth

### DIFF
--- a/src/search_space.h
+++ b/src/search_space.h
@@ -402,7 +402,7 @@ struct SearchSpace
                 // arguments woudn't exceed the maximum number of arguments
                 auto within_size_limit = !(max_arg_count) || (node.get_arg_count() <= max_arg_count);
 
-                if ( in(node_arg_types, arg) && within_size_limit) {
+                if ( in(node_arg_types, arg) && within_size_limit ) {
                     // if checking terminal compatibility, make sure there's
                     // a compatible terminal for the node's other arguments
                     if (terminal_compatible) {

--- a/src/search_space.h
+++ b/src/search_space.h
@@ -377,7 +377,7 @@ struct SearchSpace
     /// @param ret return type
     /// @param arg argument type to match
     /// @param terminal_compatible if true, the other args the returned operator takes must exist in the terminal types. 
-    /// @param max_arg_count if zero, no limit is taken to the maximum number of arguments to the operator. Otherwise, the operator will have at most `max_arg_count` arguments. 
+    /// @param max_arg_count if zero, there is no limit on number of arguments of the operator. If not, the operator can have at most `max_arg_count` arguments. 
     /// @return a matching operator. 
     Node get_op_with_arg(DataType ret, DataType arg, 
                               bool terminal_compatible=true,

--- a/src/search_space.h
+++ b/src/search_space.h
@@ -550,6 +550,12 @@ T RandomDequeue(std::vector<T>& Q)
 template<typename P>
 P SearchSpace::make_program(int max_d, int max_size)
 {
+    // A comment about PTC2 method:            
+    // PTC2 can work with depth or size restriction, but it does not strictly
+    // satisfies these conditions all time. Given a `max_size` and `max_depth`
+    // parameters, the real maximum size that can occur is `max_size` plus the
+    // highest operator arity, and the real maximum depth is `max_depth` plus one.
+
     if (max_d == 0)
         max_d = r.rnd_int(1, PARAMS["max_depth"].get<int>());
     if (max_size == 0)

--- a/src/search_space.h
+++ b/src/search_space.h
@@ -377,9 +377,11 @@ struct SearchSpace
     /// @param ret return type
     /// @param arg argument type to match
     /// @param terminal_compatible if true, the other args the returned operator takes must exist in the terminal types. 
+    /// @param max_arg_count if zero, no limit is taken to the maximum number of arguments to the operator. Otherwise, the operator will have at most `max_arg_count` arguments. 
     /// @return a matching operator. 
     Node get_op_with_arg(DataType ret, DataType arg, 
-                              bool terminal_compatible=true) const
+                              bool terminal_compatible=true,
+                              int max_arg_count=0) const
     {
         // thoughts (TODO):
         //  this could be templated by return type and arg. although the lookup in the map should be
@@ -395,7 +397,12 @@ struct SearchSpace
         for (const auto& [args_type, name_map]: args_map) {
             for (const auto& [name, node]: name_map) {
                 auto node_arg_types = node.get_arg_types();
-                if ( in(node_arg_types, arg) ) {
+                
+                // has no size limit (max_arg_count==0) or the number of
+                // arguments woudn't exceed the maximum number of arguments
+                auto within_size_limit = !(max_arg_count) || (node.get_arg_count() <= max_arg_count);
+
+                if ( in(node_arg_types, arg) && within_size_limit) {
                     // if checking terminal compatibility, make sure there's
                     // a compatible terminal for the node's other arguments
                     if (terminal_compatible) {

--- a/src/util/rnd.h
+++ b/src/util/rnd.h
@@ -64,22 +64,25 @@ namespace Brush { namespace Util{
                 return start;
             }
 
-            /// select randomly with weighted distribution
+            // TODO: write doxygen documentation for this source code.
+            /// select randomly with weighted distribution.
+            // The probability of picking the i-th element is w_i/S, with S
+            // being the sum of all weights. select_randomly works even if the
+            // weights does not sum up to 1
             template<typename Iter, typename Iter2>                                    
             Iter select_randomly(Iter start, Iter end, Iter2 wstart, Iter2 wend)
             {
+                // discrete_distribution creates a Generator for a probability
+                // distribution function. `dis` generate integers from [0, s),
+                // where `s` is the number of probabilities in the iterator 
+                // passed as argument. To generate a new value, the
+                // `operator()( Generator& g )` needs a uniform random bit
+                // generator object, which is stored in `rg`.
+
                 // std::uniform_int_distribution<> dis(0, distance(start, end) - 1);
                 std::discrete_distribution<size_t> dis(wstart, wend);
 
-                // `advance()` increments the iterator by n elements. `dis` is the
-                // discrete_distribution creates a probability distribution function,
-                // and can generate integers from [0, s), where `s` is the number of
-                // probabilities in the iterator passed as argument.
-                // to generate a new value, the `operator()( Generator& g )` needs
-                // to take a uniform random bit generator object. The brush.rnd
-                // class have a private generator `rg` that can be used.
-                // `rg` is a pseudo-random number generator vector, containing
-                // one random generator for each thread. In the line below.
+                // `advance(it, n)` increments the iterator by n elements
                 advance(start, dis(rg[omp_get_thread_num()]));
 
                 // start was originally an iterator pointing to the beggining
@@ -157,6 +160,7 @@ namespace Brush { namespace Util{
         
             ~Rnd();
             
+            // Vector of pseudo-random number generators, one for each thread
             vector<std::mt19937> rg;
             
             static Rnd* instance;

--- a/src/util/rnd.h
+++ b/src/util/rnd.h
@@ -70,7 +70,22 @@ namespace Brush { namespace Util{
             {
                 // std::uniform_int_distribution<> dis(0, distance(start, end) - 1);
                 std::discrete_distribution<size_t> dis(wstart, wend);
+
+                // `advance()` increments the iterator by n elements. `dis` is the
+                // discrete_distribution creates a probability distribution function,
+                // and can generate integers from [0, s), where `s` is the number of
+                // probabilities in the iterator passed as argument.
+                // to generate a new value, the `operator()( Generator& g )` needs
+                // to take a uniform random bit generator object. The brush.rnd
+                // class have a private generator `rg` that can be used.
+                // `rg` is a pseudo-random number generator vector, containing
+                // one random generator for each thread. In the line below.
                 advance(start, dis(rg[omp_get_thread_num()]));
+
+                // start was originally an iterator pointing to the beggining
+                // of the sequence we want to take a random value. It is incremented
+                // to point to a random element, with probabilities taken from 
+                // the second iterator Iter2.
                 return start;
             }
            

--- a/src/variation.h
+++ b/src/variation.h
@@ -118,14 +118,12 @@ Program<T> mutate(const Program<T>& parent, const SearchSpace& SS)
 
     auto options = PARAMS["mutation_options"].get<std::map<string,float>>();
 
-    // Setting the weight of mutations that increase the expression to zero
-    // if the expression is already at the maximum allowed size or maximum 
-    // depth. If not, then the insert mutation will insert an operator that
-    // does not exceed the max_size. We add one to represent the op node
-    // that would be inserted.
+    // Setting to zero the weight of variations that increase the expression
+    // if the expression is already at the maximum size or depth
     if (child.Tree.size()+1      >= PARAMS["max_size"].get<int>() ||
         child.Tree.max_depth()+1 >= PARAMS["max_depth"].get<int>() )
     {
+        // avoid using mutations that increase size/depth 
         options["insert"] = 0.0;
     }
 
@@ -186,13 +184,13 @@ Program<T> cross(const Program<T>& root, const Program<T>& other)
         auto allowed_depth = PARAMS["max_depth"].get<int>() - 
                              ( child.Tree.max_depth() - child.Tree.depth(child_spot) );
 
-        fmt::print("child_spot      : {}\n",child_spot.node->data);
-        fmt::print("child_ret_type  : {}\n",child_ret_type);
-        fmt::print("child size      : {}\n", child.Tree.size());
-        fmt::print("child depth     : {}\n", child.Tree.max_depth());
-        fmt::print("child spot size : {}\n", child.Tree.size(child_spot));
-        fmt::print("child spot depth: {}\n", child.Tree.max_depth(child_spot));
-        fmt::print("child spot model: {}\n", child_spot.node->get_model());
+        // fmt::print("child_spot      : {}\n",child_spot.node->data);
+        // fmt::print("child_ret_type  : {}\n",child_ret_type);
+        // fmt::print("child size      : {}\n", child.Tree.size());
+        // fmt::print("child depth     : {}\n", child.Tree.max_depth());
+        // fmt::print("child spot size : {}\n", child.Tree.size(child_spot));
+        // fmt::print("child spot depth: {}\n", child.Tree.max_depth(child_spot));
+        // fmt::print("child spot model: {}\n", child_spot.node->get_model());
 
         // pick a subtree to insert. Selection is based on other_weights
         vector<float> other_weights(other.Tree.size());
@@ -211,7 +209,7 @@ Program<T> cross(const Program<T>& root, const Program<T>& other)
 
         std::transform(other.Tree.begin(), other.Tree.end(), 
             other_weights.begin(),
-            [allowed_size, child_ret_type, check_and_incrm](const auto& n){
+            [child_ret_type, check_and_incrm](const auto& n){
                 // need to pick a node that has a matching output type to the child_spot.
                 // also need to check if swaping this node wouldn't exceed max_size
                 if (check_and_incrm() && (n.ret_type == child_ret_type))

--- a/src/variation.h
+++ b/src/variation.h
@@ -120,8 +120,8 @@ Program<T> mutate(const Program<T>& parent, const SearchSpace& SS)
 
     // Setting to zero the weight of variations that increase the expression
     // if the expression is already at the maximum size or depth
-    if (child.Tree.size()+1      >= PARAMS["max_size"].get<int>() ||
-        child.Tree.max_depth()+1 >= PARAMS["max_depth"].get<int>() )
+    if (child.Tree.size()+1      >= PARAMS["max_size"].get<int>()
+    ||  child.Tree.max_depth()+1 >= PARAMS["max_depth"].get<int>())
     {
         // avoid using mutations that increase size/depth 
         options["insert"] = 0.0;
@@ -166,7 +166,6 @@ Program<T> cross(const Program<T>& root, const Program<T>& other)
                     [](const auto& n){ return n.get_prob_change(); }
                     );
     
-    // fmt::print("child weights: {}\n", child_weights);
     // GUI TODO: Keep doing random attempts, or test all possilities?
     bool matching_spots_found = false;
     for (int tries = 0; tries < 3; ++tries)
@@ -183,14 +182,6 @@ Program<T> cross(const Program<T>& root, const Program<T>& other)
                              ( child.Tree.size() - child.Tree.size(child_spot) );
         auto allowed_depth = PARAMS["max_depth"].get<int>() - 
                              ( child.Tree.max_depth() - child.Tree.depth(child_spot) );
-
-        // fmt::print("child_spot      : {}\n",child_spot.node->data);
-        // fmt::print("child_ret_type  : {}\n",child_ret_type);
-        // fmt::print("child size      : {}\n", child.Tree.size());
-        // fmt::print("child depth     : {}\n", child.Tree.max_depth());
-        // fmt::print("child spot size : {}\n", child.Tree.size(child_spot));
-        // fmt::print("child spot depth: {}\n", child.Tree.max_depth(child_spot));
-        // fmt::print("child spot model: {}\n", child_spot.node->get_model());
 
         // pick a subtree to insert. Selection is based on other_weights
         vector<float> other_weights(other.Tree.size());
@@ -230,9 +221,6 @@ Program<T> cross(const Program<T>& root, const Program<T>& other)
 
         if (matching_spots_found) 
         {
-            // The probability of picking the i-th element is w_i/S, with S being
-            // the sum of all weights. select_randomly works with a weight vector
-            // even if the weights does not sum up to 1
             auto other_spot = r.select_randomly(
                 other.Tree.begin(), 
                 other.Tree.end(), 

--- a/tests/cpp/test_program.cpp
+++ b/tests/cpp/test_program.cpp
@@ -190,10 +190,26 @@ TEST(Operators, ProgramMaxSizePARAMS)
             fmt::print("make_regressor\n");
             RegressorProgram PRG = SS.make_regressor(0, 0);
             
-            auto PRG_model = PRG.get_model("compact", true);
+            fmt::print(
+                "depth = {}, size= {}\n"
+                "Generated Model: {}\n"
+                "=================================================\n",
+                d, s, 
+                PRG.get_model("compact", true)
+            );
+
+            // A comment about PTC2 method:            
+            // PTC2 ensures that the depth does not exceed the maximum limit,
+            // and that the number of nodes does not exceed the maximum limit
+            // plus the highest arity of the function nodes, that is:
+            // `max_size + max(arity(f)), for f in function_set`
+
+            // split operator --> arity 3
+            // prod operator  --> arity 4
+            int max_arity = 4;
 
             ASSERT_TRUE(PRG.size() > 0);
-            ASSERT_TRUE(PRG.size() <= s);
+            ASSERT_TRUE(PRG.size() <= s+max_arity);
         }
     }
 }

--- a/tests/cpp/test_program.cpp
+++ b/tests/cpp/test_program.cpp
@@ -179,6 +179,16 @@ TEST(Operators, ProgramMaxSizePARAMS)
     SearchSpace SS;
     SS.init(data);
 
+    // A comment about PTC2 method:            
+    // PTC2 ensures that the depth does not exceed the maximum limit,
+    // and that the number of nodes does not exceed the maximum limit
+    // plus the highest arity of the function nodes, that is:
+    // `max_size + max(arity(f)), for f in function_set`
+
+    // split operator --> arity 3
+    // prod operator  --> arity 4
+    int max_arity = 4;
+
     for (int d = 1; d < 10; ++d)
     {
         for (int s = 1; s < 10; ++s)
@@ -197,16 +207,6 @@ TEST(Operators, ProgramMaxSizePARAMS)
                 d, s, 
                 PRG.get_model("compact", true)
             );
-
-            // A comment about PTC2 method:            
-            // PTC2 ensures that the depth does not exceed the maximum limit,
-            // and that the number of nodes does not exceed the maximum limit
-            // plus the highest arity of the function nodes, that is:
-            // `max_size + max(arity(f)), for f in function_set`
-
-            // split operator --> arity 3
-            // prod operator  --> arity 4
-            int max_arity = 4;
 
             ASSERT_TRUE(PRG.size() > 0);
             ASSERT_TRUE(PRG.size() <= s+max_arity);

--- a/tests/cpp/test_program.cpp
+++ b/tests/cpp/test_program.cpp
@@ -161,7 +161,7 @@ TEST(Program, Serialization)
     }
 }
 
-TEST(Operators, ProgramMaxSizePARAMS)
+TEST(Operators, ProgramSizeAndDepthPARAMS)
 {
     MatrixXf X(10,2);
     ArrayXf y(10);
@@ -183,7 +183,8 @@ TEST(Operators, ProgramMaxSizePARAMS)
     // PTC2 ensures that the depth does not exceed the maximum limit,
     // and that the number of nodes does not exceed the maximum limit
     // plus the highest arity of the function nodes, that is:
-    // `max_size + max(arity(f)), for f in function_set`
+    // `max_size + max(arity(f)), for f in function_set`.
+    // For the depth, the PTC2 guarantees at most max_depth+1
 
     // split operator --> arity 3
     // prod operator  --> arity 4
@@ -203,13 +204,27 @@ TEST(Operators, ProgramMaxSizePARAMS)
             fmt::print(
                 "depth = {}, size= {}\n"
                 "Generated Model: {}\n"
+                "Model depth    : {}\n"
+                "Model size     : {}\n"
                 "=================================================\n",
                 d, s, 
-                PRG.get_model("compact", true)
+                PRG.get_model("compact", true), PRG.Tree.max_depth(), PRG.Tree.size()
             );
+
+            // There are two ways of assessing the size of a program
+            // GUI TODO: which style are we going to use? i) implement
+            // PRG.max_depth() (or PRG.depth()); or ii) get rid of PRG.size()
+            // and use always PRG.Tree.<>)
+            ASSERT_TRUE(PRG.Tree.size() > 0);
+            ASSERT_TRUE(PRG.Tree.size() <= s+max_arity);
 
             ASSERT_TRUE(PRG.size() > 0);
             ASSERT_TRUE(PRG.size() <= s+max_arity);
+
+            // GUI TODO: max_depth() counts the number of edges (so a program with
+            // one node has max_depth()==0). Is this how it should behave?
+            ASSERT_TRUE(PRG.Tree.max_depth() >= 0);
+            ASSERT_TRUE(PRG.Tree.max_depth() <= d+1);
         }
     }
 }

--- a/tests/cpp/test_program.cpp
+++ b/tests/cpp/test_program.cpp
@@ -179,13 +179,6 @@ TEST(Operators, ProgramSizeAndDepthPARAMS)
     SearchSpace SS;
     SS.init(data);
 
-    // A comment about PTC2 method:            
-    // PTC2 ensures that the depth does not exceed the maximum limit,
-    // and that the number of nodes does not exceed the maximum limit
-    // plus the highest arity of the function nodes, that is:
-    // `max_size + max(arity(f)), for f in function_set`.
-    // For the depth, the PTC2 guarantees at most max_depth+1
-
     // split operator --> arity 3
     // prod operator  --> arity 4
     int max_arity = 4;

--- a/tests/cpp/test_program.cpp
+++ b/tests/cpp/test_program.cpp
@@ -111,9 +111,6 @@ TEST(Program, FitClassifier)
     }
 }
 
-
-
-
 TEST(Program, Serialization)
 {
     // test mutation
@@ -160,6 +157,43 @@ TEST(Program, Serialization)
             newPRG.fit(data);
             ArrayXf new_y_pred = newPRG.predict(data);
 
+        }
+    }
+}
+
+TEST(Operators, ProgramMaxSizePARAMS)
+{
+    MatrixXf X(10,2);
+    ArrayXf y(10);
+    X << 0.85595296, 0.55417453, 0.8641915 , 0.99481109, 0.99123376,
+         0.9742618 , 0.70894019, 0.94940306, 0.99748867, 0.54205151,
+
+         0.5170537 , 0.8324005 , 0.50316305, 0.10173936, 0.13211973,
+         0.2254195 , 0.70526861, 0.31406024, 0.07082619, 0.84034526;
+
+    y << 3.55634251, 3.13854087, 3.55887523, 3.29462895, 3.33443517,
+         3.4378868 , 3.41092345, 3.5087468 , 3.25110243, 3.11382179;
+
+    Dataset data(X,y);
+
+    SearchSpace SS;
+    SS.init(data);
+
+    for (int d = 1; d < 10; ++d)
+    {
+        for (int s = 1; s < 10; ++s)
+        {
+            PARAMS["max_size"]  = s;
+            PARAMS["max_depth"] = d;
+
+            fmt::print("d={},s={}\n",d,s);
+            fmt::print("make_regressor\n");
+            RegressorProgram PRG = SS.make_regressor(0, 0);
+            
+            auto PRG_model = PRG.get_model("compact", true);
+
+            ASSERT_TRUE(PRG.size() > 0);
+            ASSERT_TRUE(PRG.size() <= s);
         }
     }
 }

--- a/tests/cpp/test_variation.cpp
+++ b/tests/cpp/test_variation.cpp
@@ -170,7 +170,9 @@ TEST(Operators, MutationMaxSizeLimit)
             // Original didn't change
             ASSERT_TRUE(PRG_model == PRG.get_model("compact", true));
             
-            // Child is within restrictions
+            // Child is within restrictions. Here we expect the generated
+            // expression to have at most max_size nodes (there is no tolerance 
+            // gap as PTC2 has)
             ASSERT_TRUE(Child.size() > 0);
             ASSERT_TRUE(Child.size() <= s);
         }

--- a/tests/cpp/test_variation.cpp
+++ b/tests/cpp/test_variation.cpp
@@ -208,12 +208,21 @@ TEST(Operators, CrossoverMaxSizeLimit)
     SearchSpace SS;
     SS.init(data);
 
-    for (int d = 1; d < 10; ++d)
+    // split operator --> arity 3
+    // prod operator  --> arity 4
+    int max_arity = 4;
+
+    for (int d = 5; d < 15; ++d)
     {
-        for (int s = 1; s < 10; ++s)
+        for (int s = 5; s < 15; ++s)
         {
-            RegressorProgram PRG1 = SS.make_regressor(d, s);
-            RegressorProgram PRG2 = SS.make_regressor(d, s);
+            PARAMS["max_size"]  = s;
+            PARAMS["max_depth"] = d;
+
+            // Enforcing that the parents does not exceed max_size by
+            // taking into account the highest arity of the function nodes
+            RegressorProgram PRG1 = SS.make_regressor(d, s-max_arity);
+            RegressorProgram PRG2 = SS.make_regressor(d, s-max_arity);
 
             auto PRG1_model = PRG1.get_model("compact", true);
             auto PRG2_model = PRG2.get_model("compact", true);
@@ -331,6 +340,10 @@ TEST(Operators, CrossoverMaxSizePARAMS)
     SearchSpace SS;
     SS.init(data);
 
+    // split operator --> arity 3
+    // prod operator  --> arity 4
+    int max_arity = 4;
+
     for (int d = 1; d < 10; ++d)
     {
         for (int s = 1; s < 10; ++s)
@@ -338,8 +351,8 @@ TEST(Operators, CrossoverMaxSizePARAMS)
             PARAMS["max_size"]  = s;
             PARAMS["max_depth"] = d;
 
-            RegressorProgram PRG1 = SS.make_regressor(d, s);
-            RegressorProgram PRG2 = SS.make_regressor(d, s);
+            RegressorProgram PRG1 = SS.make_regressor(0, 0);
+            RegressorProgram PRG2 = SS.make_regressor(0, 0);
 
             auto PRG1_model = PRG1.get_model("compact", true);
             auto PRG2_model = PRG2.get_model("compact", true);
@@ -349,11 +362,11 @@ TEST(Operators, CrossoverMaxSizePARAMS)
 
             // Child1 is within restrictions
             ASSERT_TRUE(Child1.size() > 0);
-            ASSERT_TRUE(Child1.size() <= s);
+            ASSERT_TRUE(Child1.size() <= s+max_arity);
 
             // Child2 is within restrictions
             ASSERT_TRUE(Child2.size() > 0);
-            ASSERT_TRUE(Child2.size() <= s);
+            ASSERT_TRUE(Child2.size() <= s+max_arity);
         }
     }
 }

--- a/tests/cpp/test_variation.cpp
+++ b/tests/cpp/test_variation.cpp
@@ -8,7 +8,7 @@ TEST(Operators, Mutation)
 {
     PARAMS["mutation_options"] = {
         {"point",0.25}, {"insert", 0.25}, {"delete", 0.25}, {"toggle_weight", 0.25}
-        };
+    };
     // test mutation
     // TODO: set random seed
     MatrixXf X(10,2);
@@ -59,14 +59,18 @@ TEST(Operators, Crossover)
 {
     // test mutation
     // TODO: set random seed
+
     MatrixXf X(10,2);
     ArrayXf y(10);
     X << 0.85595296, 0.55417453, 0.8641915 , 0.99481109, 0.99123376,
          0.9742618 , 0.70894019, 0.94940306, 0.99748867, 0.54205151,
+
          0.5170537 , 0.8324005 , 0.50316305, 0.10173936, 0.13211973,
          0.2254195 , 0.70526861, 0.31406024, 0.07082619, 0.84034526;
+
     y << 3.55634251, 3.13854087, 3.55887523, 3.29462895, 3.33443517,
-             3.4378868 , 3.41092345, 3.5087468 , 3.25110243, 3.11382179;
+         3.4378868 , 3.41092345, 3.5087468 , 3.25110243, 3.11382179;
+
     Dataset data(X,y);
 
     SearchSpace SS;
@@ -114,6 +118,223 @@ TEST(Operators, Crossover)
             Child2.fit(data);
             auto child_pred1 = Child1.predict(data);
             auto child_pred2 = Child2.predict(data);
+        }
+    }
+}
+
+TEST(Operators, MutationMaxSizeLimit)
+{
+    PARAMS["mutation_options"] = {
+        {"point",0.25}, {"insert", 0.25}, {"delete", 0.25}, {"toggle_weight", 0.25}
+    };
+        
+    MatrixXf X(10,2);
+    ArrayXf y(10);
+    X << 0.85595296, 0.55417453, 0.8641915 , 0.99481109, 0.99123376,
+         0.9742618 , 0.70894019, 0.94940306, 0.99748867, 0.54205151,
+
+         0.5170537 , 0.8324005 , 0.50316305, 0.10173936, 0.13211973,
+         0.2254195 , 0.70526861, 0.31406024, 0.07082619, 0.84034526;
+
+    y << 3.55634251, 3.13854087, 3.55887523, 3.29462895, 3.33443517,
+         3.4378868 , 3.41092345, 3.5087468 , 3.25110243, 3.11382179;
+
+    Dataset data(X,y);
+
+    SearchSpace SS;
+    SS.init(data);
+
+    for (int d = 1; d < 10; ++d)
+    {
+        for (int s = 1; s < 10; ++s)
+        {
+            fmt::print("d={},s={}\n",d,s);
+            fmt::print("make_regressor\n");
+            RegressorProgram PRG = SS.make_regressor(d, s);
+            
+            auto PRG_model = PRG.get_model("compact", true);
+
+            auto Child = PRG.mutate();
+
+            fmt::print("print\n");
+            fmt::print(
+                "=================================================\n"
+                "depth = {}, size= {}\n"
+                "Initial Model: {}\n"
+                "Mutated Model: {}\n",
+                d, s, 
+                PRG.get_model("compact", true),
+                Child.get_model("compact", true)
+            );
+
+            // Original didn't change
+            ASSERT_TRUE(PRG_model == PRG.get_model("compact", true));
+            
+            // Child is within restrictions
+            ASSERT_TRUE(Child.size() > 0);
+            ASSERT_TRUE(Child.size() <= s);
+        }
+    }
+}
+
+TEST(Operators, CrossoverMaxSizeLimit)
+{
+    MatrixXf X(10,2);
+    ArrayXf y(10);
+    X << 0.85595296, 0.55417453, 0.8641915 , 0.99481109, 0.99123376,
+         0.9742618 , 0.70894019, 0.94940306, 0.99748867, 0.54205151,
+
+         0.5170537 , 0.8324005 , 0.50316305, 0.10173936, 0.13211973,
+         0.2254195 , 0.70526861, 0.31406024, 0.07082619, 0.84034526;
+
+    y << 3.55634251, 3.13854087, 3.55887523, 3.29462895, 3.33443517,
+         3.4378868 , 3.41092345, 3.5087468 , 3.25110243, 3.11382179;
+
+    Dataset data(X,y);
+
+    SearchSpace SS;
+    SS.init(data);
+
+    for (int d = 1; d < 10; ++d)
+    {
+        for (int s = 1; s < 10; ++s)
+        {
+            RegressorProgram PRG1 = SS.make_regressor(d, s);
+            RegressorProgram PRG2 = SS.make_regressor(d, s);
+
+            auto PRG1_model = PRG1.get_model("compact", true);
+            auto PRG2_model = PRG2.get_model("compact", true);
+
+            fmt::print(
+                "=================================================\n"
+                "depth = {}, size= {}\n"
+                "Initial Model 1: {}\n"
+                "Initial Model 2: {}\n",
+                d, s, 
+                PRG1.get_model("compact", true),
+                PRG2.get_model("compact", true)
+            );
+
+            fmt::print("cross one\n");
+            auto Child1 = PRG1.cross(PRG2);
+            fmt::print(
+                "Model 1 after cross: {}\n"
+                "Model 2 after cross: {}\n",
+                PRG1.get_model("compact", true),
+                PRG2.get_model("compact", true)
+            );
+
+            fmt::print("cross two\n");
+            auto Child2 = PRG2.cross(PRG1);
+            fmt::print(
+                "Crossed Model 1: {}\n"
+                "Crossed Model 2: {}\n"
+                "=================================================\n",
+                Child1.get_model("compact", true),
+                Child2.get_model("compact", true)
+            );
+
+            // Original didn't change
+            ASSERT_TRUE(PRG1_model == PRG1.get_model("compact", true));
+            ASSERT_TRUE(PRG2_model == PRG2.get_model("compact", true));
+
+            // Child1 is within restrictions
+            ASSERT_TRUE(Child1.size() > 0);
+            ASSERT_TRUE(Child1.size() <= s);
+
+            // Child2 is within restrictions
+            ASSERT_TRUE(Child2.size() > 0);
+            ASSERT_TRUE(Child2.size() <= s);
+        }
+    }
+}
+
+TEST(Operators, MutationMaxSizePARAMS)
+{
+    PARAMS["mutation_options"] = {
+        {"point",0.25}, {"insert", 0.25}, {"delete", 0.25}, {"toggle_weight", 0.25}
+    };
+        
+    MatrixXf X(10,2);
+    ArrayXf y(10);
+    X << 0.85595296, 0.55417453, 0.8641915 , 0.99481109, 0.99123376,
+         0.9742618 , 0.70894019, 0.94940306, 0.99748867, 0.54205151,
+
+         0.5170537 , 0.8324005 , 0.50316305, 0.10173936, 0.13211973,
+         0.2254195 , 0.70526861, 0.31406024, 0.07082619, 0.84034526;
+
+    y << 3.55634251, 3.13854087, 3.55887523, 3.29462895, 3.33443517,
+         3.4378868 , 3.41092345, 3.5087468 , 3.25110243, 3.11382179;
+
+    Dataset data(X,y);
+
+    SearchSpace SS;
+    SS.init(data);
+
+    for (int d = 1; d < 10; ++d)
+    {
+        for (int s = 1; s < 10; ++s)
+        {
+            PARAMS["max_size"]  = s;
+            PARAMS["max_depth"] = d;
+
+
+            fmt::print("d={},s={}\n",d,s);
+            fmt::print("make_regressor\n");
+            RegressorProgram PRG = SS.make_regressor(0, 0);
+            
+            auto PRG_model = PRG.get_model("compact", true);
+
+            auto Child = PRG.mutate();
+
+            // Child is within restrictions
+            ASSERT_TRUE(Child.size() > 0);
+            ASSERT_TRUE(Child.size() <= s);
+        }
+    }
+}
+
+TEST(Operators, CrossoverMaxSizePARAMS)
+{
+    MatrixXf X(10,2);
+    ArrayXf y(10);
+    X << 0.85595296, 0.55417453, 0.8641915 , 0.99481109, 0.99123376,
+         0.9742618 , 0.70894019, 0.94940306, 0.99748867, 0.54205151,
+
+         0.5170537 , 0.8324005 , 0.50316305, 0.10173936, 0.13211973,
+         0.2254195 , 0.70526861, 0.31406024, 0.07082619, 0.84034526;
+
+    y << 3.55634251, 3.13854087, 3.55887523, 3.29462895, 3.33443517,
+         3.4378868 , 3.41092345, 3.5087468 , 3.25110243, 3.11382179;
+
+    Dataset data(X,y);
+
+    SearchSpace SS;
+    SS.init(data);
+
+    for (int d = 1; d < 10; ++d)
+    {
+        for (int s = 1; s < 10; ++s)
+        {
+            PARAMS["max_size"]  = s;
+            PARAMS["max_depth"] = d;
+
+            RegressorProgram PRG1 = SS.make_regressor(d, s);
+            RegressorProgram PRG2 = SS.make_regressor(d, s);
+
+            auto PRG1_model = PRG1.get_model("compact", true);
+            auto PRG2_model = PRG2.get_model("compact", true);
+
+            auto Child1 = PRG1.cross(PRG2);
+            auto Child2 = PRG2.cross(PRG1);
+
+            // Child1 is within restrictions
+            ASSERT_TRUE(Child1.size() > 0);
+            ASSERT_TRUE(Child1.size() <= s);
+
+            // Child2 is within restrictions
+            ASSERT_TRUE(Child2.size() > 0);
+            ASSERT_TRUE(Child2.size() <= s);
         }
     }
 }


### PR DESCRIPTION
This pull request attempts to solve Issue #27.


## Tests:

The test file `test_variation.cpp` implements tests to check if `PARAMS["max_size"]` or `PARAMS["max_depth"]` have any effect on the expressions after applying the variation methods. The problem of testing these constraints is that expressions are generated using PTC2 --- while this is an excellent method, it is important to notice that:
* if the maximum size is `max_size`, and the highest operator arity is `max_arity`, the generated tree can have a size of at most `max_size+max_arity`;
* if the maximum depth is `max_depth`, the generated program can have a depth of at most `max_depth+1`.

The tests, then, are divided into two groups. The former checks the variation sizes/depths **considering additional nodes**, and the later creates expressions with PTC2 by **subtracting the possible additional size/depth**.

I also create some tests in `test_program` to see if PTC2 works properly.

## Mutation:

Function `get_op_with_arg` has a new parameter, with default behavior being exactly as it was before I added `max_arg_count`. This parameter is used to specify the maximum number of arguments that the node can have.

https://github.com/cavalab/brush/blob/4ef1b9907333893a98c0a4facb64b2309eed0ba0/src/search_space.h#L376-L384

Mutation avoid exceeding the max size/depth by checking:

https://github.com/cavalab/brush/blob/4ef1b9907333893a98c0a4facb64b2309eed0ba0/src/variation.h#L121-L128

The idea is that every mutation that can increase the size or depth should be inside this `if` block. 

Although I could do a more fine check for the `depth`(since inserting a node not always increase the maximum depth of the tree), this would require the enumeration of some points were the mutation could be applied, creating an overhead.

## Crossover:

Based on the `child_point` I need to check --- for every candidate in the `other.Tree` --- if: 
* It has the same argument type at its relative root;
* replacing `child_point` with the `other` subtree woudn't create an tree with more nodes than `PARAMS["max_size"]`, or a depth higher than `PARAMS["max_depth"]`.

First, I get the allowed size and depth:

https://github.com/cavalab/brush/blob/4ef1b9907333893a98c0a4facb64b2309eed0ba0/src/variation.h#L182-L186

then I created an iterator and a lambda function to check if the candidate is valid:

https://github.com/cavalab/brush/blob/4ef1b9907333893a98c0a4facb64b2309eed0ba0/src/variation.h#L199-L208

So this can be simply included in the previously implemented check (checks if the argument type is valid):

https://github.com/cavalab/brush/blob/4ef1b9907333893a98c0a4facb64b2309eed0ba0/src/variation.h#L210-L221


## Small improvements:

There are some changes that I would like to point here so we can discuss! I wrote them in the code with `GUI TODO`.

https://github.com/cavalab/brush/blob/4ef1b9907333893a98c0a4facb64b2309eed0ba0/src/variation.h#L52
        
https://github.com/cavalab/brush/blob/4ef1b9907333893a98c0a4facb64b2309eed0ba0/src/variation.h#L170

https://github.com/cavalab/brush/blob/4ef1b9907333893a98c0a4facb64b2309eed0ba0/tests/cpp/test_program.cpp#L214-L222

https://github.com/cavalab/brush/blob/4ef1b9907333893a98c0a4facb64b2309eed0ba0/tests/cpp/test_program.cpp#L224-L227

